### PR TITLE
Model-first supervisor escalation with profile resolver and guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ JoshGPT VS Code extension for LM Studio with MCP tools, canonical workspace inst
 
 - Chat backend: LM Studio (`openai-compat` or `lmstudio-native-stream`).
 - MCP tools: loaded from `joshgpt.mcp.baseUrl` (execution tools are hidden from model exposure).
-- Supervisor escalation: extension-side wrapper tool only.
+- Supervisor escalation: model-first + extension-side wrapper orchestration.
   - Wrapper internally orchestrates:
     - `dispatch_role_task`
     - `submit_supervisor_question`
@@ -16,6 +16,48 @@ JoshGPT VS Code extension for LM Studio with MCP tools, canonical workspace inst
     - `JOSHGPT_DISPATCHER_SHARED_TOKEN`
     - `JOSHGPT_SUPERVISOR_SHARED_TOKEN`
   - Raw token fields are never model-visible.
+
+## Supervisor Trigger Model
+
+- Default behavior: prompts go to the local model first; the model decides when to call `request_codex_supervisor_decision`.
+- Model-visible supervisor args are intentionally minimal (`question` + optional reason/context fields).
+- Extension injects role/scope metadata from profile resolution (never from model-provided token/role fields).
+- Manual fallback is available:
+  - Command Palette: `JoshGPT: Escalate To Supervisor`
+  - Session UI: `Escalate` button
+
+Guardrails:
+
+- per-turn escalation cap (`joshgpt.supervisor.maxEscalationsPerTurn`)
+- per-session escalation cap (`joshgpt.supervisor.maxEscalationsPerSession`)
+- cooldown / duplicate suppression (`joshgpt.supervisor.escalationCooldownMs`)
+
+Readiness:
+
+- automatic preflight in prompt runs
+- manual status check via `JoshGPT: Check Supervisor Status`
+
+## Supervision Profile Resolution
+
+Role bindings are resolved in this order:
+
+1. `<workspaceRoot>/.joshgpt/supervision.json` (canonical)
+2. settings fallback:
+   - `joshgpt.supervisor.workerRoleSlug`
+   - `joshgpt.supervisor.supervisorRoleSlug`
+
+Canonical profile format:
+
+```json
+{
+  "version": 1,
+  "worker_role_slug": "implementation-specialist",
+  "supervisor_role_slug": "hr-ai-agent-specialist",
+  "authorized_scope_id": "extension-supervisor-scope",
+  "authorized_targets": ["workspace"],
+  "requested_decision_default": "next_step"
+}
+```
 
 ## Instruction Inheritance
 
@@ -51,8 +93,14 @@ Trace metadata includes:
 Existing settings remain. Added cutover settings:
 
 - `joshgpt.supervisor.enabled`
+- `joshgpt.supervisor.modelEscalationEnabled`
 - `joshgpt.supervisor.dispatcherBaseUrl`
 - `joshgpt.supervisor.capabilityBaseUrl`
+- `joshgpt.supervisor.maxEscalationsPerTurn`
+- `joshgpt.supervisor.maxEscalationsPerSession`
+- `joshgpt.supervisor.escalationCooldownMs`
+- `joshgpt.supervisor.workerRoleSlug`
+- `joshgpt.supervisor.supervisorRoleSlug`
 - `joshgpt.instructions.inheritVscodeInstructions`
 - `joshgpt.instructions.maxChars`
 
@@ -92,6 +140,8 @@ npm run test:local-shell
 npm run test:native
 npm run test:mcp
 npm run test:instructions
+npm run test:supervision-profile
+npm run test:supervisor-readiness
 npm run test:supervisor-wrapper
 ```
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "onCommand:joshgpt.newSession",
     "onCommand:joshgpt.listModels",
     "onCommand:joshgpt.askModel",
-    "onCommand:joshgpt.mcpStatus"
+    "onCommand:joshgpt.mcpStatus",
+    "onCommand:joshgpt.checkSupervisorStatus",
+    "onCommand:joshgpt.escalateToSupervisor"
   ],
   "main": "./src/extension.js",
   "contributes": {
@@ -49,6 +51,14 @@
       {
         "command": "joshgpt.mcpStatus",
         "title": "JoshGPT: MCP Status"
+      },
+      {
+        "command": "joshgpt.checkSupervisorStatus",
+        "title": "JoshGPT: Check Supervisor Status"
+      },
+      {
+        "command": "joshgpt.escalateToSupervisor",
+        "title": "JoshGPT: Escalate To Supervisor"
       }
     ],
     "viewsContainers": {
@@ -147,6 +157,11 @@
           "default": true,
           "description": "Enable extension-side Codex supervisor wrapper tool in openai-compat mode."
         },
+        "joshgpt.supervisor.modelEscalationEnabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allow the model to initiate supervisor escalation via request_codex_supervisor_decision."
+        },
         "joshgpt.supervisor.dispatcherBaseUrl": {
           "type": "string",
           "default": "http://127.0.0.1:8788/mcp",
@@ -156,6 +171,34 @@
           "type": "string",
           "default": "http://127.0.0.1:8789/mcp",
           "description": "Supervisor capability MCP endpoint (ask_codex_supervisor)."
+        },
+        "joshgpt.supervisor.maxEscalationsPerTurn": {
+          "type": "number",
+          "default": 1,
+          "minimum": 1,
+          "description": "Guardrail: maximum supervisor escalations allowed per prompt turn."
+        },
+        "joshgpt.supervisor.maxEscalationsPerSession": {
+          "type": "number",
+          "default": 3,
+          "minimum": 1,
+          "description": "Guardrail: maximum supervisor escalations allowed per session."
+        },
+        "joshgpt.supervisor.escalationCooldownMs": {
+          "type": "number",
+          "default": 15000,
+          "minimum": 0,
+          "description": "Guardrail: minimum cooldown interval between supervisor escalations."
+        },
+        "joshgpt.supervisor.workerRoleSlug": {
+          "type": "string",
+          "default": "",
+          "description": "Fallback worker role slug used when .joshgpt/supervision.json is missing."
+        },
+        "joshgpt.supervisor.supervisorRoleSlug": {
+          "type": "string",
+          "default": "",
+          "description": "Fallback supervisor role slug used when .joshgpt/supervision.json is missing."
         },
         "joshgpt.instructions.inheritVscodeInstructions": {
           "type": "boolean",
@@ -222,6 +265,8 @@
     "test:native": "node ./scripts/native-stream-self-test.js",
     "test:mcp": "node ./scripts/mcp-self-test.js",
     "test:instructions": "node ./scripts/instruction-resolver-self-test.js",
+    "test:supervision-profile": "node ./scripts/supervision-profile-self-test.js",
+    "test:supervisor-readiness": "node ./scripts/supervisor-readiness-self-test.js",
     "test:supervisor-wrapper": "node ./scripts/supervisor-wrapper-self-test.js",
     "package:vsix": "npx @vscode/vsce package --no-dependencies",
     "package:latest-vsix": "npx @vscode/vsce package --no-dependencies --out joshgpt-latest.vsix"

--- a/scripts/supervision-profile-self-test.js
+++ b/scripts/supervision-profile-self-test.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { resolveSupervisionProfile } = require("../src/supervision-profile-resolver");
+
+function withTempDir(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "joshgpt-supervision-profile-"));
+  try {
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function writeProfile(workspaceRoot, body) {
+  const filePath = path.join(workspaceRoot, ".joshgpt", "supervision.json");
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(body, null, 2), "utf8");
+}
+
+function testWorkspaceProfilePreferred() {
+  withTempDir((workspaceRoot) => {
+    writeProfile(workspaceRoot, {
+      version: 1,
+      worker_role_slug: "implementation-specialist",
+      supervisor_role_slug: "hr-ai-agent-specialist",
+      authorized_scope_id: "extension-supervisor-scope",
+      authorized_targets: ["workspace"],
+      requested_decision_default: "next_step"
+    });
+
+    const result = resolveSupervisionProfile({
+      workspaceRoot,
+      settingsFallback: {
+        workerRoleSlug: "fallback-worker",
+        supervisorRoleSlug: "fallback-supervisor"
+      }
+    });
+    assert.strictEqual(result.resolved, true);
+    assert.strictEqual(result.source, "workspace_file");
+    assert.strictEqual(result.profile.workerRoleSlug, "implementation-specialist");
+  });
+}
+
+function testSettingsFallback() {
+  withTempDir((workspaceRoot) => {
+    const result = resolveSupervisionProfile({
+      workspaceRoot,
+      settingsFallback: {
+        workerRoleSlug: "fallback-worker",
+        supervisorRoleSlug: "fallback-supervisor"
+      }
+    });
+    assert.strictEqual(result.resolved, true);
+    assert.strictEqual(result.source, "settings_fallback");
+    assert.ok(result.warning.includes("settings fallback"));
+  });
+}
+
+function testMissingAllProfiles() {
+  withTempDir((workspaceRoot) => {
+    const result = resolveSupervisionProfile({
+      workspaceRoot,
+      settingsFallback: {}
+    });
+    assert.strictEqual(result.resolved, false);
+    assert.strictEqual(result.source, "none");
+    assert.ok(result.error.length > 0);
+  });
+}
+
+function main() {
+  testWorkspaceProfilePreferred();
+  testSettingsFallback();
+  testMissingAllProfiles();
+  console.log("[supervision-profile-test] PASS");
+}
+
+main();

--- a/scripts/supervisor-readiness-self-test.js
+++ b/scripts/supervisor-readiness-self-test.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("assert");
+const { checkSupervisorReadiness } = require("../src/supervisor-readiness");
+
+function createClientFactory(map = {}) {
+  return function mcpClientFactory(options) {
+    const baseUrl = String(options.baseUrl || "");
+    const tools = Array.isArray(map[baseUrl]) ? map[baseUrl] : [];
+    return {
+      async listTools() {
+        return tools.map((name) => ({ name }));
+      }
+    };
+  };
+}
+
+async function testHappyPath() {
+  const readiness = await checkSupervisorReadiness({
+    dispatcherBaseUrl: "http://127.0.0.1:8788/mcp",
+    capabilityBaseUrl: "http://127.0.0.1:8789/mcp",
+    env: {
+      JOSHGPT_DISPATCHER_SHARED_TOKEN: "dispatcher-token",
+      JOSHGPT_SUPERVISOR_SHARED_TOKEN: "supervisor-token"
+    },
+    mcpClientFactory: createClientFactory({
+      "http://127.0.0.1:8788/mcp": [
+        "dispatch_role_task",
+        "submit_supervisor_question",
+        "respond_supervisor_question"
+      ],
+      "http://127.0.0.1:8789/mcp": ["ask_codex_supervisor"]
+    })
+  });
+  assert.strictEqual(readiness.ready, true);
+  assert.strictEqual(readiness.status, "ready");
+}
+
+async function testMissingToken() {
+  const readiness = await checkSupervisorReadiness({
+    dispatcherBaseUrl: "http://127.0.0.1:8788/mcp",
+    capabilityBaseUrl: "http://127.0.0.1:8789/mcp",
+    env: {},
+    mcpClientFactory: createClientFactory({
+      "http://127.0.0.1:8788/mcp": [
+        "dispatch_role_task",
+        "submit_supervisor_question",
+        "respond_supervisor_question"
+      ],
+      "http://127.0.0.1:8789/mcp": ["ask_codex_supervisor"]
+    })
+  });
+  assert.strictEqual(readiness.ready, false);
+  assert.strictEqual(readiness.status, "blocked");
+  assert.ok(readiness.summary.includes("dispatcher_token"));
+}
+
+async function testMissingRequiredTool() {
+  const readiness = await checkSupervisorReadiness({
+    dispatcherBaseUrl: "http://127.0.0.1:8788/mcp",
+    capabilityBaseUrl: "http://127.0.0.1:8789/mcp",
+    env: {
+      JOSHGPT_DISPATCHER_SHARED_TOKEN: "dispatcher-token",
+      JOSHGPT_SUPERVISOR_SHARED_TOKEN: "supervisor-token"
+    },
+    mcpClientFactory: createClientFactory({
+      "http://127.0.0.1:8788/mcp": ["dispatch_role_task"],
+      "http://127.0.0.1:8789/mcp": ["ask_codex_supervisor"]
+    })
+  });
+  assert.strictEqual(readiness.ready, false);
+  assert.ok(readiness.summary.includes("Missing required tool"));
+}
+
+async function main() {
+  await testHappyPath();
+  await testMissingToken();
+  await testMissingRequiredTool();
+  console.log("[supervisor-readiness-test] PASS");
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`[supervisor-readiness-test] FAIL: ${msg}`);
+  process.exit(1);
+});

--- a/scripts/supervisor-wrapper-self-test.js
+++ b/scripts/supervisor-wrapper-self-test.js
@@ -4,15 +4,21 @@
 const assert = require("assert");
 const {
   runSupervisorWrapperToolCall,
-  buildGuardedSupervisorMessage
+  buildGuardedSupervisorMessage,
+  evaluateSupervisorEscalationGuardrails
 } = require("../src/supervisor-wrapper-tool");
 
 const DEFAULT_INPUT = {
-  worker_role_slug: "worker-analyst",
-  supervisor_role_slug: "codex-supervisor",
-  objective: "Confirm escalation behavior.",
   escalation_reason: "insufficient_context",
   question: "Should we proceed with current evidence?"
+};
+
+const DEFAULT_PROFILE = {
+  workerRoleSlug: "worker-analyst",
+  supervisorRoleSlug: "codex-supervisor",
+  authorizedScopeId: "extension-supervisor-scope",
+  authorizedTargets: ["workspace"],
+  requestedDecisionDefault: "next_step"
 };
 
 function createClientFactory({
@@ -55,6 +61,12 @@ async function testHappyPath() {
       JOSHGPT_DISPATCHER_SHARED_TOKEN: "dispatcher-token",
       JOSHGPT_SUPERVISOR_SHARED_TOKEN: "supervisor-token"
     },
+    supervisionProfile: DEFAULT_PROFILE,
+    supervisionProfileSource: "workspace_file",
+    sessionContext: {
+      objective: "Confirm escalation behavior.",
+      roleContextRef: "workspace://AGENTS.md"
+    },
     mcpClientFactory: createClientFactory({
       dispatcherHandlers: {
         dispatch_role_task: () => ({ structuredContent: { task_id: "task-1", status: "queued" } }),
@@ -83,7 +95,8 @@ async function testMissingEnvToken() {
     capabilityBaseUrl: "http://127.0.0.1:8789/mcp",
     env: {
       JOSHGPT_DISPATCHER_SHARED_TOKEN: "dispatcher-token"
-    }
+    },
+    supervisionProfile: DEFAULT_PROFILE
   });
 
   assert.strictEqual(result.ok, false);
@@ -98,6 +111,11 @@ async function testDispatcherFailure() {
     env: {
       JOSHGPT_DISPATCHER_SHARED_TOKEN: "dispatcher-token",
       JOSHGPT_SUPERVISOR_SHARED_TOKEN: "supervisor-token"
+    },
+    supervisionProfile: DEFAULT_PROFILE,
+    sessionContext: {
+      objective: "Confirm escalation behavior.",
+      roleContextRef: "workspace://AGENTS.md"
     },
     mcpClientFactory: createClientFactory({
       dispatcherHandlers: {
@@ -123,6 +141,11 @@ async function testFailSafeDecisionPropagation() {
       JOSHGPT_DISPATCHER_SHARED_TOKEN: "dispatcher-token",
       JOSHGPT_SUPERVISOR_SHARED_TOKEN: "supervisor-token"
     },
+    supervisionProfile: DEFAULT_PROFILE,
+    sessionContext: {
+      objective: "Confirm escalation behavior.",
+      roleContextRef: "workspace://AGENTS.md"
+    },
     mcpClientFactory: createClientFactory({
       dispatcherHandlers: {
         dispatch_role_task: () => ({ structuredContent: { task_id: "task-2", status: "queued" } }),
@@ -144,11 +167,32 @@ async function testFailSafeDecisionPropagation() {
   assert.ok(guarded.includes("pause_for_human"));
 }
 
+function testGuardrailPolicy() {
+  const first = evaluateSupervisorEscalationGuardrails({
+    input: { question: "Need next step" },
+    state: { turnEscalationCount: 0, sessionEscalationCount: 0 },
+    policy: { maxPerTurn: 1, maxPerSession: 2, cooldownMs: 15000 },
+    nowMs: 1000
+  });
+  assert.strictEqual(first.allowed, true);
+  assert.strictEqual(first.state.turnEscalationCount, 1);
+
+  const second = evaluateSupervisorEscalationGuardrails({
+    input: { question: "Need next step" },
+    state: first.state,
+    policy: { maxPerTurn: 1, maxPerSession: 2, cooldownMs: 15000 },
+    nowMs: 2000
+  });
+  assert.strictEqual(second.allowed, false);
+  assert.ok(second.reason.includes("per-turn limit"));
+}
+
 async function main() {
   await testHappyPath();
   await testMissingEnvToken();
   await testDispatcherFailure();
   await testFailSafeDecisionPropagation();
+  testGuardrailPolicy();
   console.log("[supervisor-wrapper-test] PASS");
 }
 

--- a/src/chat-runner.js
+++ b/src/chat-runner.js
@@ -14,9 +14,13 @@ const {
   SUPERVISOR_WRAPPER_TOOL_NAME,
   INTERNAL_SUPERVISOR_TOOL_NAMES,
   getSupervisorWrapperOpenAiTool,
+  evaluateSupervisorEscalationGuardrails,
+  buildGuardrailBlockedWrapperResult,
   runSupervisorWrapperToolCall,
   buildGuardedSupervisorMessage
 } = require("./supervisor-wrapper-tool");
+const { resolveSupervisionProfile } = require("./supervision-profile-resolver");
+const { checkSupervisorReadiness } = require("./supervisor-readiness");
 
 const MCP_EXECUTION_TOOL_NAMES = new Set([
   "run_host_command",
@@ -181,6 +185,20 @@ function addInstructionTrace(addTrace, instructionInheritance) {
   }
 }
 
+function formatSupervisorCheckDetails(result, stage) {
+  return JSON.stringify(
+    {
+      stage: String(stage || ""),
+      status: String(result?.status || "blocked"),
+      ready: Boolean(result?.ready),
+      summary: String(result?.summary || ""),
+      checks: Array.isArray(result?.checks) ? result.checks : []
+    },
+    null,
+    2
+  );
+}
+
 async function runNativeStreamingMode({ config, messages, output, trace, addTrace }) {
   addTrace("start", "Prompt execution started (mode=lmstudio-native-stream).");
 
@@ -262,7 +280,41 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
   const localShellEnabled = Boolean(config.localShellEnabled);
   const localTools = localShellEnabled ? [getLocalShellOpenAiTool()] : [];
   const supervisorEnabled = Boolean(config.supervisorEnabled);
-  const supervisorTools = supervisorEnabled ? [getSupervisorWrapperOpenAiTool()] : [];
+  const supervisorModelEscalationEnabled = Boolean(
+    config.supervisorModelEscalationEnabled ?? true
+  );
+  const supervisorProfileResolution = supervisorEnabled
+    ? resolveSupervisionProfile({
+        workspaceRoot: config.workspaceRoot,
+        settingsFallback: {
+          workerRoleSlug: config.supervisorWorkerRoleSlug,
+          supervisorRoleSlug: config.supervisorSupervisorRoleSlug
+        }
+      })
+    : {
+        resolved: false,
+        source: "none",
+        profile: null,
+        warning: "",
+        error: ""
+      };
+  const supervisorTools =
+    supervisorEnabled && supervisorModelEscalationEnabled
+      ? [getSupervisorWrapperOpenAiTool()]
+      : [];
+  let supervisorPreflight = {
+    ready: false,
+    status: "blocked",
+    summary: "Supervisor readiness check not run.",
+    checks: []
+  };
+  let supervisorPreflightRechecked = false;
+  let supervisorGuardrailState = {
+    turnEscalationCount: 0,
+    sessionEscalationCount: Math.max(0, Number(config.supervisorEscalationsInSession) || 0),
+    lastEscalationAtMs: Math.max(0, Number(config.supervisorLastEscalationAtMs) || 0),
+    lastEscalationQuestionHash: String(config.supervisorLastEscalationQuestionHash || "")
+  };
 
   let mcpClient = null;
   let openAiTools = [];
@@ -272,6 +324,45 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
     "start",
     `Prompt execution started (mcp=${mcpEnabled ? "enabled" : "disabled"}, local_shell=${localShellEnabled ? "enabled" : "disabled"}, supervisor=${supervisorEnabled ? "enabled" : "disabled"})`
   );
+  if (supervisorEnabled) {
+    if (supervisorProfileResolution.resolved) {
+      addTrace(
+        "supervision-profile",
+        `Supervisor profile resolved from ${supervisorProfileResolution.source}.`,
+        JSON.stringify(
+          {
+            source: supervisorProfileResolution.source,
+            profile_file: supervisorProfileResolution.filePath || null,
+            worker_role_slug: supervisorProfileResolution.profile?.workerRoleSlug || "",
+            supervisor_role_slug:
+              supervisorProfileResolution.profile?.supervisorRoleSlug || ""
+          },
+          null,
+          2
+        )
+      );
+      if (supervisorProfileResolution.warning) {
+        addTrace("supervision-profile-warning", supervisorProfileResolution.warning);
+      }
+    } else {
+      addTrace(
+        "supervision-profile-error",
+        "Supervisor profile could not be resolved.",
+        String(supervisorProfileResolution.error || "")
+      );
+    }
+    supervisorPreflight = await checkSupervisorReadiness({
+      dispatcherBaseUrl: config.supervisorDispatcherBaseUrl,
+      capabilityBaseUrl: config.supervisorCapabilityBaseUrl,
+      timeoutMs: config.mcpTimeoutMs,
+      output
+    });
+    addTrace(
+      "supervisor-preflight",
+      `Supervisor readiness: ${supervisorPreflight.status}`,
+      formatSupervisorCheckDetails(supervisorPreflight, "session_start")
+    );
+  }
 
   if (mcpEnabled) {
     try {
@@ -282,7 +373,14 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
       });
       const mcpTools = await mcpClient.listTools();
       const mcpOpenAiTools = asOpenAiTools(mcpTools, MCP_HIDDEN_TOOL_NAMES);
-      openAiTools = [...localTools, ...supervisorTools, ...mcpOpenAiTools];
+      const supervisorToolsForTurn =
+        supervisorEnabled &&
+        supervisorModelEscalationEnabled &&
+        supervisorProfileResolution.resolved &&
+        supervisorPreflight.ready
+          ? supervisorTools
+          : [];
+      openAiTools = [...localTools, ...supervisorToolsForTurn, ...mcpOpenAiTools];
       if (!openAiTools.length) {
         addTrace("mcp", "MCP connected but no tools were returned.");
         mcpEnabled = false;
@@ -303,7 +401,14 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
       addTrace("mcp", "MCP disabled for this turn.", msg);
       mcpEnabled = false;
       if (localShellEnabled || supervisorEnabled) {
-        openAiTools = [...localTools, ...supervisorTools];
+        const supervisorToolsForTurn =
+          supervisorEnabled &&
+          supervisorModelEscalationEnabled &&
+          supervisorProfileResolution.resolved &&
+          supervisorPreflight.ready
+            ? supervisorTools
+            : [];
+        openAiTools = [...localTools, ...supervisorToolsForTurn];
         if (output) {
           output.appendLine(
             "[joshgpt] Falling back to extension-local tools for this turn."
@@ -313,7 +418,14 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
       }
     }
   } else if (localShellEnabled || supervisorEnabled) {
-    openAiTools = [...localTools, ...supervisorTools];
+    const supervisorToolsForTurn =
+      supervisorEnabled &&
+      supervisorModelEscalationEnabled &&
+      supervisorProfileResolution.resolved &&
+      supervisorPreflight.ready
+        ? supervisorTools
+        : [];
+    openAiTools = [...localTools, ...supervisorToolsForTurn];
     addTrace("tool", "MCP disabled; extension-local tools are active.");
   }
 
@@ -326,15 +438,31 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
       addTrace("tool", "Ensured local shell tool availability for this turn.");
     }
   }
-  if (supervisorEnabled) {
+  if (supervisorEnabled && supervisorModelEscalationEnabled) {
+    if (!supervisorProfileResolution.resolved) {
+      addTrace(
+        "supervisor",
+        "Supervisor wrapper tool withheld: unresolved supervision profile."
+      );
+    } else if (!supervisorPreflight.ready) {
+      addTrace(
+        "supervisor",
+        "Supervisor wrapper tool withheld: readiness preflight is blocked."
+      );
+    }
     const hasSupervisorTool = openAiTools.some(
       (tool) =>
         tool && tool.function && tool.function.name === SUPERVISOR_WRAPPER_TOOL_NAME
     );
-    if (!hasSupervisorTool) {
+    if (!hasSupervisorTool && supervisorProfileResolution.resolved && supervisorPreflight.ready) {
       openAiTools = [...supervisorTools, ...openAiTools];
       addTrace("tool", "Ensured supervisor wrapper tool availability for this turn.");
     }
+  } else if (supervisorEnabled) {
+    addTrace(
+      "supervisor",
+      "Model-initiated supervisor escalation disabled by configuration."
+    );
   }
 
   const workingMessages = Array.isArray(messages) ? [...messages] : [];
@@ -372,6 +500,7 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
         text: response.text,
         usedTools: usedToolsInTurn,
         rounds: round + 1,
+        supervisorGuardrailState,
         trace
       };
     }
@@ -428,17 +557,66 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
           addTrace("tool-error", `Local shell failed: ${toolName}`, msg);
         }
       } else if (toolName === SUPERVISOR_WRAPPER_TOOL_NAME) {
-        const wrapperResult = await runSupervisorWrapperToolCall(args, {
-          dispatcherBaseUrl: config.supervisorDispatcherBaseUrl,
-          capabilityBaseUrl: config.supervisorCapabilityBaseUrl,
-          timeoutMs: config.mcpTimeoutMs,
-          output
-        });
-        toolResultText = JSON.stringify(wrapperResult, null, 2);
         addTrace(
-          "supervisor",
+          "supervisor-escalation-request",
+          "Supervisor escalation requested by model.",
+          JSON.stringify(args, null, 2).slice(0, 1200)
+        );
+        if (!supervisorPreflightRechecked) {
+          supervisorPreflightRechecked = true;
+          supervisorPreflight = await checkSupervisorReadiness({
+            dispatcherBaseUrl: config.supervisorDispatcherBaseUrl,
+            capabilityBaseUrl: config.supervisorCapabilityBaseUrl,
+            timeoutMs: config.mcpTimeoutMs,
+            output
+          });
+          addTrace(
+            "supervisor-preflight",
+            `Supervisor readiness: ${supervisorPreflight.status}`,
+            formatSupervisorCheckDetails(supervisorPreflight, "before_first_escalation")
+          );
+        }
+        const guardrailEval = evaluateSupervisorEscalationGuardrails({
+          input: args,
+          state: supervisorGuardrailState,
+          policy: {
+            maxPerTurn: config.supervisorMaxEscalationsPerTurn,
+            maxPerSession: config.supervisorMaxEscalationsPerSession,
+            cooldownMs: config.supervisorEscalationCooldownMs
+          }
+        });
+        let wrapperResult;
+        if (!supervisorProfileResolution.resolved) {
+          wrapperResult = buildGuardrailBlockedWrapperResult(
+            `Missing supervision profile: ${supervisorProfileResolution.error || "role binding unavailable."}`
+          );
+        } else if (!supervisorPreflight.ready) {
+          wrapperResult = buildGuardrailBlockedWrapperResult(
+            `Supervisor preflight blocked: ${supervisorPreflight.summary}`
+          );
+        } else if (!guardrailEval.allowed) {
+          wrapperResult = buildGuardrailBlockedWrapperResult(guardrailEval.reason);
+        } else {
+          supervisorGuardrailState = guardrailEval.state;
+          wrapperResult = await runSupervisorWrapperToolCall(args, {
+            dispatcherBaseUrl: config.supervisorDispatcherBaseUrl,
+            capabilityBaseUrl: config.supervisorCapabilityBaseUrl,
+            timeoutMs: config.mcpTimeoutMs,
+            output,
+            supervisionProfile: supervisorProfileResolution.profile,
+            supervisionProfileSource: supervisorProfileResolution.source,
+            sessionContext: config.supervisorSessionContext || {}
+          });
+        }
+        toolResultText = JSON.stringify(wrapperResult, null, 2);
+        const supervisorTracePayload = {
+          wrapper_result: wrapperResult,
+          guardrail_state: supervisorGuardrailState
+        };
+        addTrace(
+          "supervisor-escalation-decision",
           `Supervisor wrapper result: action=${wrapperResult.action}`,
-          toolResultText.slice(0, 1200)
+          JSON.stringify(supervisorTracePayload, null, 2).slice(0, 1200)
         );
         if (wrapperResult.action === "terminate") {
           addTrace(
@@ -449,6 +627,7 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
             text: buildGuardedSupervisorMessage(wrapperResult),
             usedTools: true,
             rounds: round + 1,
+            supervisorGuardrailState,
             trace
           };
         }
@@ -490,6 +669,7 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
       "Reached tool-call round limit before final response. Increase joshgpt.mcp.maxToolRounds if needed.",
     usedTools: true,
     rounds: maxRounds,
+    supervisorGuardrailState,
     trace
   };
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -9,6 +9,8 @@ const { McpHttpClient } = require("./mcp-client");
 const { runChatWithOptionalMcp } = require("./chat-runner");
 const { createLocalShellMirror } = require("./local-shell-mirror");
 const { resolveInheritedInstructions } = require("./instruction-resolver");
+const { resolveSupervisionProfile } = require("./supervision-profile-resolver");
+const { checkSupervisorReadiness } = require("./supervisor-readiness");
 
 const DEFAULT_MCP_BASE_URL = "http://127.0.0.1:8790/mcp";
 const DEFAULT_NATIVE_BASE_URL = "http://localhost:1234";
@@ -51,6 +53,9 @@ function getConfig() {
     mcpTimeoutMs: Number(rootCfg.get("joshgpt.mcp.timeoutMs") || 15000),
     mcpMaxToolRounds: Number(rootCfg.get("joshgpt.mcp.maxToolRounds") || 4),
     supervisorEnabled: Boolean(rootCfg.get("joshgpt.supervisor.enabled") ?? true),
+    supervisorModelEscalationEnabled: Boolean(
+      rootCfg.get("joshgpt.supervisor.modelEscalationEnabled") ?? true
+    ),
     supervisorDispatcherBaseUrl: normalizeBaseUrl(
       String(
         rootCfg.get("joshgpt.supervisor.dispatcherBaseUrl") ||
@@ -63,6 +68,21 @@ function getConfig() {
           DEFAULT_SUPERVISOR_CAPABILITY_BASE_URL
       )
     ),
+    supervisorMaxEscalationsPerTurn: Number(
+      rootCfg.get("joshgpt.supervisor.maxEscalationsPerTurn") || 1
+    ),
+    supervisorMaxEscalationsPerSession: Number(
+      rootCfg.get("joshgpt.supervisor.maxEscalationsPerSession") || 3
+    ),
+    supervisorEscalationCooldownMs: Number(
+      rootCfg.get("joshgpt.supervisor.escalationCooldownMs") || 15000
+    ),
+    supervisorWorkerRoleSlug: String(
+      rootCfg.get("joshgpt.supervisor.workerRoleSlug") || ""
+    ).trim(),
+    supervisorSupervisorRoleSlug: String(
+      rootCfg.get("joshgpt.supervisor.supervisorRoleSlug") || ""
+    ).trim(),
     instructionsInheritVscodeInstructions: Boolean(
       rootCfg.get("joshgpt.instructions.inheritVscodeInstructions") ?? true
     ),
@@ -210,7 +230,16 @@ async function askModel(output) {
   const { text } = await runChatWithOptionalMcp({
     config: {
       ...cfg,
-      instructionInheritance
+      instructionInheritance,
+      supervisorSessionContext: {
+        objective: userPrompt,
+        roleContextRef: instructionInheritance.canonicalPath || "workspace://AGENTS.md",
+        attemptHistory: [],
+        evidenceSummary: "",
+        blockedReason: "insufficient_context",
+        currentPhase: "validation",
+        requestedDecision: "next_step"
+      }
     },
     messages: modelMessages,
     output
@@ -250,6 +279,54 @@ async function mcpStatus(output) {
   vscode.window.showInformationMessage(
     `JoshGPT MCP connected: ${names.length} tool(s) at ${cfg.mcpBaseUrl}`
   );
+}
+
+async function supervisorStatus(output) {
+  const cfg = getConfig();
+  if (!cfg.supervisorEnabled) {
+    vscode.window.showInformationMessage(
+      "Supervisor flow is disabled (joshgpt.supervisor.enabled=false)."
+    );
+    return;
+  }
+
+  const profile = resolveSupervisionProfile({
+    workspaceRoot: cfg.workspaceRoot,
+    settingsFallback: {
+      workerRoleSlug: cfg.supervisorWorkerRoleSlug,
+      supervisorRoleSlug: cfg.supervisorSupervisorRoleSlug
+    }
+  });
+  const readiness = await checkSupervisorReadiness({
+    dispatcherBaseUrl: cfg.supervisorDispatcherBaseUrl,
+    capabilityBaseUrl: cfg.supervisorCapabilityBaseUrl,
+    timeoutMs: cfg.mcpTimeoutMs,
+    output
+  });
+  output.appendLine(`[joshgpt] supervisor_status=${readiness.status}`);
+  output.appendLine(`[joshgpt] supervisor_summary=${readiness.summary}`);
+  output.appendLine(
+    `[joshgpt] supervision_profile_source=${profile.source} resolved=${profile.resolved ? "yes" : "no"}`
+  );
+  if (profile.warning) {
+    output.appendLine(`[joshgpt] supervision_profile_warning=${profile.warning}`);
+  }
+  if (profile.error) {
+    output.appendLine(`[joshgpt] supervision_profile_error=${profile.error}`);
+  }
+  output.show(true);
+  if (readiness.ready && profile.resolved) {
+    vscode.window.showInformationMessage("Supervisor readiness check passed.");
+  } else {
+    const msg = [
+      `Supervisor status: ${readiness.status}.`,
+      profile.resolved ? "" : `Profile error: ${profile.error || "missing role bindings."}`,
+      readiness.summary
+    ]
+      .filter(Boolean)
+      .join(" ");
+    vscode.window.showWarningMessage(msg);
+  }
 }
 
 function activate(context) {
@@ -313,6 +390,31 @@ function activate(context) {
     vscode.commands.registerCommand("joshgpt.mcpStatus", async () => {
       try {
         await mcpStatus(output);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        output.appendLine(`[joshgpt] error: ${msg}`);
+        vscode.window.showErrorMessage(msg);
+      }
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("joshgpt.checkSupervisorStatus", async () => {
+      try {
+        await supervisorStatus(output);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        output.appendLine(`[joshgpt] error: ${msg}`);
+        vscode.window.showErrorMessage(msg);
+      }
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("joshgpt.escalateToSupervisor", async () => {
+      try {
+        await vscode.commands.executeCommand("workbench.view.extension.joshgpt");
+        await sessionProvider.escalateActiveSessionFromCommand();
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         output.appendLine(`[joshgpt] error: ${msg}`);

--- a/src/session-view-provider.js
+++ b/src/session-view-provider.js
@@ -4,6 +4,14 @@ const vscode = require("vscode");
 const { SessionStore } = require("./session-store");
 const { runChatWithOptionalMcp } = require("./chat-runner");
 const { resolveInheritedInstructions } = require("./instruction-resolver");
+const { resolveSupervisionProfile } = require("./supervision-profile-resolver");
+const { checkSupervisorReadiness } = require("./supervisor-readiness");
+const {
+  runSupervisorWrapperToolCall,
+  evaluateSupervisorEscalationGuardrails,
+  buildGuardrailBlockedWrapperResult,
+  buildGuardedSupervisorMessage
+} = require("./supervisor-wrapper-tool");
 
 const SETTINGS_EXTENSION_ID = "josh-phillips-llc.joshgpt";
 const SETTINGS_FIELDS = [
@@ -20,8 +28,14 @@ const SETTINGS_FIELDS = [
   { key: "mcp.timeoutMs", type: "number", min: 1000 },
   { key: "mcp.maxToolRounds", type: "number", min: 1, max: 12 },
   { key: "supervisor.enabled", type: "boolean" },
+  { key: "supervisor.modelEscalationEnabled", type: "boolean" },
   { key: "supervisor.dispatcherBaseUrl", type: "string" },
   { key: "supervisor.capabilityBaseUrl", type: "string" },
+  { key: "supervisor.maxEscalationsPerTurn", type: "number", min: 1 },
+  { key: "supervisor.maxEscalationsPerSession", type: "number", min: 1 },
+  { key: "supervisor.escalationCooldownMs", type: "number", min: 0 },
+  { key: "supervisor.workerRoleSlug", type: "string" },
+  { key: "supervisor.supervisorRoleSlug", type: "string" },
   { key: "instructions.inheritVscodeInstructions", type: "boolean" },
   { key: "instructions.maxChars", type: "number", min: 1024 },
   { key: "localShell.enabled", type: "boolean" },
@@ -33,6 +47,133 @@ const SETTINGS_FIELDS = [
   { key: "localShell.mirrorTerminalName", type: "string" },
   { key: "localShell.mirrorTerminalReveal", type: "boolean" }
 ];
+
+function asString(value) {
+  return String(value || "").trim();
+}
+
+function safeJsonParseObject(text) {
+  try {
+    const parsed = JSON.parse(String(text || ""));
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch {
+    // Ignore invalid JSON in trace details.
+  }
+  return null;
+}
+
+function normalizeOneLine(text, maxChars = 260) {
+  const normalized = asString(text).replace(/\s+/g, " ");
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxChars)}...`;
+}
+
+function deriveLatestAssistantEvidence(session) {
+  const messages = Array.isArray(session && session.messages) ? session.messages : [];
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const item = messages[i];
+    if (item && item.role === "assistant" && asString(item.content)) {
+      return normalizeOneLine(item.content, 600);
+    }
+  }
+  return "";
+}
+
+function deriveAttemptHistory(session, maxItems = 8) {
+  const events = Array.isArray(session && session.traceEvents) ? session.traceEvents : [];
+  const out = [];
+  for (let i = events.length - 1; i >= 0 && out.length < maxItems; i -= 1) {
+    const event = events[i];
+    const summary = normalizeOneLine(event && event.summary, 160);
+    if (!summary) {
+      continue;
+    }
+    out.push(summary);
+  }
+  return out.reverse();
+}
+
+function deriveObjective(session, promptFallback = "") {
+  const prompt = normalizeOneLine(promptFallback, 260);
+  if (prompt) {
+    return prompt;
+  }
+  const messages = Array.isArray(session && session.messages) ? session.messages : [];
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const item = messages[i];
+    if (item && item.role === "user" && asString(item.content)) {
+      return normalizeOneLine(item.content, 260);
+    }
+  }
+  return "Resolve the active workspace blocker safely.";
+}
+
+function deriveGuardrailSeed(session) {
+  const events = Array.isArray(session && session.traceEvents) ? session.traceEvents : [];
+  let sessionEscalationsInSession = 0;
+  let lastEscalationAtMs = 0;
+  let lastEscalationQuestionHash = "";
+  for (let i = 0; i < events.length; i += 1) {
+    const event = events[i];
+    if (!event || String(event.type || "") !== "supervisor-escalation-decision") {
+      continue;
+    }
+    sessionEscalationsInSession += 1;
+    const eventTime = Date.parse(String(event.timestamp || ""));
+    if (Number.isFinite(eventTime)) {
+      lastEscalationAtMs = Math.max(lastEscalationAtMs, eventTime);
+    }
+    const parsed = safeJsonParseObject(event.details);
+    const guardrailState =
+      parsed &&
+      parsed.guardrail_state &&
+      typeof parsed.guardrail_state === "object"
+        ? parsed.guardrail_state
+        : null;
+    if (guardrailState) {
+      const parsedAt = Number(guardrailState.lastEscalationAtMs);
+      if (Number.isFinite(parsedAt)) {
+        lastEscalationAtMs = Math.max(lastEscalationAtMs, parsedAt);
+      }
+      const parsedHash = asString(guardrailState.lastEscalationQuestionHash);
+      if (parsedHash) {
+        lastEscalationQuestionHash = parsedHash;
+      }
+    }
+  }
+  return {
+    sessionEscalationsInSession,
+    lastEscalationAtMs,
+    lastEscalationQuestionHash
+  };
+}
+
+function formatSupervisorDecisionMessage(wrapperResult) {
+  const decision =
+    wrapperResult && wrapperResult.decision && typeof wrapperResult.decision === "object"
+      ? wrapperResult.decision
+      : {};
+  if (wrapperResult && wrapperResult.action === "terminate") {
+    return buildGuardedSupervisorMessage(wrapperResult);
+  }
+  const lines = [];
+  lines.push(`Supervisor decision: ${asString(decision.decision) || "proceed"}`);
+  if (asString(decision.rationale)) {
+    lines.push(`Rationale: ${asString(decision.rationale)}`);
+  }
+  lines.push(`Terminal: ${Boolean(wrapperResult && wrapperResult.terminal)}`);
+  const nextActions = Array.isArray(decision.next_actions) ? decision.next_actions : [];
+  let idx = 1;
+  for (const action of nextActions) {
+    lines.push(`Next action ${idx}: ${String(action)}`);
+    idx += 1;
+  }
+  return lines.join("\n");
+}
 
 function makeNonce() {
   const chars =
@@ -112,6 +253,10 @@ class JoshGptSessionViewProvider {
   async createSessionFromCommand() {
     await this.store.createSession();
     await this._postState();
+  }
+
+  async escalateActiveSessionFromCommand() {
+    await this._escalateToSupervisor();
   }
 
   _settingsConfig() {
@@ -218,6 +363,11 @@ class JoshGptSessionViewProvider {
       return;
     }
 
+    if (type === "escalateToSupervisor") {
+      await this._escalateToSupervisor();
+      return;
+    }
+
     if (type === "reloadSettings") {
       await this._postState();
       return;
@@ -270,6 +420,17 @@ class JoshGptSessionViewProvider {
         enabled: cfg.instructionsInheritVscodeInstructions,
         maxChars: cfg.instructionsMaxChars
       });
+      const objective = deriveObjective(latestSession, prompt);
+      const guardrailSeed = deriveGuardrailSeed(latestSession);
+      const supervisorSessionContext = {
+        objective,
+        roleContextRef: instructionInheritance.canonicalPath || "workspace://AGENTS.md",
+        attemptHistory: deriveAttemptHistory(latestSession, 8),
+        evidenceSummary: deriveLatestAssistantEvidence(latestSession),
+        blockedReason: "insufficient_context",
+        currentPhase: "validation",
+        requestedDecision: "next_step"
+      };
 
       const modelMessages = [];
       if (instructionInheritance.applied && instructionInheritance.systemMessage) {
@@ -298,7 +459,11 @@ class JoshGptSessionViewProvider {
       const { text, trace } = await runChatWithOptionalMcp({
         config: {
           ...cfg,
-          instructionInheritance
+          instructionInheritance,
+          supervisorSessionContext,
+          supervisorEscalationsInSession: guardrailSeed.sessionEscalationsInSession,
+          supervisorLastEscalationAtMs: guardrailSeed.lastEscalationAtMs,
+          supervisorLastEscalationQuestionHash: guardrailSeed.lastEscalationQuestionHash
         },
         messages: modelMessages,
         output: this.output
@@ -323,6 +488,203 @@ class JoshGptSessionViewProvider {
       ]);
       this.output.appendLine(`[joshgpt] session completion error: ${msg}`);
       vscode.window.showErrorMessage(msg);
+    } finally {
+      this.busy = false;
+      await this._postState();
+    }
+  }
+
+  async _escalateToSupervisor() {
+    if (this.busy) {
+      vscode.window.showInformationMessage("JoshGPT is busy. Wait for current run to finish.");
+      return;
+    }
+    this.busy = true;
+    await this._postState();
+    try {
+      const activeSession = await this.store.ensureActiveSession();
+      const session = this.store.getSessionById(activeSession.id);
+      if (!session) {
+        throw new Error("Active session not found.");
+      }
+
+      const cfg = this.getConfig();
+      if (!cfg.supervisorEnabled) {
+        throw new Error("Supervisor is disabled (joshgpt.supervisor.enabled=false).");
+      }
+
+      const question = asString(
+        await vscode.window.showInputBox({
+          title: "Escalate to Supervisor",
+          placeHolder: "Describe what decision you need from supervisor.",
+          prompt: "Enter a focused escalation question.",
+          ignoreFocusOut: true
+        })
+      );
+      if (!question) {
+        return;
+      }
+
+      const reasonChoice = await vscode.window.showQuickPick(
+        [
+          { label: "Need next step", value: "insufficient_context" },
+          { label: "Tool error", value: "tool_error" },
+          { label: "Ambiguous result", value: "ambiguous_result" },
+          { label: "Policy conflict", value: "policy_conflict" },
+          { label: "Repeated failure", value: "repeated_failure" }
+        ],
+        {
+          title: "Escalation reason",
+          placeHolder: "Select the closest reason."
+        }
+      );
+      if (!reasonChoice) {
+        return;
+      }
+
+    const instructionInheritance = resolveInheritedInstructions({
+      workspaceRoot: cfg.workspaceRoot,
+      enabled: cfg.instructionsInheritVscodeInstructions,
+      maxChars: cfg.instructionsMaxChars
+    });
+    const profile = resolveSupervisionProfile({
+      workspaceRoot: cfg.workspaceRoot,
+      settingsFallback: {
+        workerRoleSlug: cfg.supervisorWorkerRoleSlug,
+        supervisorRoleSlug: cfg.supervisorSupervisorRoleSlug
+      }
+    });
+    const readiness = await checkSupervisorReadiness({
+      dispatcherBaseUrl: cfg.supervisorDispatcherBaseUrl,
+      capabilityBaseUrl: cfg.supervisorCapabilityBaseUrl,
+      timeoutMs: cfg.mcpTimeoutMs,
+      output: this.output
+    });
+
+    const guardrailSeed = deriveGuardrailSeed(session);
+    const guardrailEval = evaluateSupervisorEscalationGuardrails({
+      input: { question },
+      state: {
+        turnEscalationCount: 0,
+        sessionEscalationCount: guardrailSeed.sessionEscalationsInSession,
+        lastEscalationAtMs: guardrailSeed.lastEscalationAtMs,
+        lastEscalationQuestionHash: guardrailSeed.lastEscalationQuestionHash
+      },
+      policy: {
+        maxPerTurn: cfg.supervisorMaxEscalationsPerTurn,
+        maxPerSession: cfg.supervisorMaxEscalationsPerSession,
+        cooldownMs: cfg.supervisorEscalationCooldownMs
+      }
+    });
+
+    const supervisorSessionContext = {
+      objective: deriveObjective(session, question),
+      roleContextRef: instructionInheritance.canonicalPath || "workspace://AGENTS.md",
+      attemptHistory: deriveAttemptHistory(session, 8),
+      evidenceSummary: deriveLatestAssistantEvidence(session),
+      blockedReason: reasonChoice.value,
+      currentPhase: "validation",
+      requestedDecision: "next_step"
+    };
+
+    let wrapperResult;
+    if (!profile.resolved) {
+      wrapperResult = buildGuardrailBlockedWrapperResult(
+        `Missing supervision profile: ${profile.error || "role binding unavailable."}`
+      );
+    } else if (!readiness.ready) {
+      wrapperResult = buildGuardrailBlockedWrapperResult(
+        `Supervisor preflight blocked: ${readiness.summary}`
+      );
+    } else if (!guardrailEval.allowed) {
+      wrapperResult = buildGuardrailBlockedWrapperResult(guardrailEval.reason);
+    } else {
+      wrapperResult = await runSupervisorWrapperToolCall(
+        {
+          question,
+          escalation_reason: "manual_user_request",
+          blocked_reason: reasonChoice.value
+        },
+        {
+          dispatcherBaseUrl: cfg.supervisorDispatcherBaseUrl,
+          capabilityBaseUrl: cfg.supervisorCapabilityBaseUrl,
+          timeoutMs: cfg.mcpTimeoutMs,
+          output: this.output,
+          supervisionProfile: profile.profile,
+          supervisionProfileSource: profile.source,
+          sessionContext: supervisorSessionContext
+        }
+      );
+    }
+
+    const trace = [
+      {
+        timestamp: new Date().toISOString(),
+        type: "supervisor-preflight",
+        summary: `Supervisor readiness: ${readiness.status}`,
+        details: JSON.stringify(
+          {
+            status: readiness.status,
+            summary: readiness.summary,
+            checks: readiness.checks
+          },
+          null,
+          2
+        )
+      },
+      {
+        timestamp: new Date().toISOString(),
+        type: "supervision-profile",
+        summary: profile.resolved
+          ? `Supervisor profile resolved from ${profile.source}.`
+          : "Supervisor profile unresolved.",
+        details: JSON.stringify(
+          {
+            source: profile.source,
+            resolved: profile.resolved,
+            error: profile.error || "",
+            warning: profile.warning || "",
+            filePath: profile.filePath || null
+          },
+          null,
+          2
+        )
+      },
+      {
+        timestamp: new Date().toISOString(),
+        type: "supervisor-escalation-request",
+        summary: "Manual escalation submitted.",
+        details: JSON.stringify(
+          {
+            question,
+            blocked_reason: reasonChoice.value
+          },
+          null,
+          2
+        )
+      },
+      {
+        timestamp: new Date().toISOString(),
+        type: "supervisor-escalation-decision",
+        summary: `Supervisor wrapper result: action=${wrapperResult.action}`,
+        details: JSON.stringify(
+          {
+            wrapper_result: wrapperResult,
+            guardrail_state: guardrailEval.state
+          },
+          null,
+          2
+        )
+      }
+    ];
+
+      await this.store.appendMessage(
+        activeSession.id,
+        "assistant",
+        formatSupervisorDecisionMessage(wrapperResult)
+      );
+      await this.store.appendTraceEvents(activeSession.id, trace);
+      await this._postState();
     } finally {
       this.busy = false;
       await this._postState();
@@ -644,6 +1006,7 @@ class JoshGptSessionViewProvider {
         <div id="chatTitle" class="chat-title">No active session</div>
         <div class="chat-actions">
           <button id="toggleSessionsBtn" class="secondary">Show Sessions</button>
+          <button id="escalateBtn" class="secondary">Escalate</button>
           <button id="deleteSessionBtn" class="secondary">Delete</button>
         </div>
       </div>
@@ -689,6 +1052,7 @@ class JoshGptSessionViewProvider {
     const titleEl = document.getElementById("chatTitle");
     const messagesEl = document.getElementById("messages");
     const sendBtn = document.getElementById("sendBtn");
+    const escalateBtn = document.getElementById("escalateBtn");
     const promptInput = document.getElementById("promptInput");
     const toggleSessionsBtn = document.getElementById("toggleSessionsBtn");
     const deleteBtn = document.getElementById("deleteSessionBtn");
@@ -755,11 +1119,13 @@ class JoshGptSessionViewProvider {
         messagesEl.appendChild(empty);
         titleEl.textContent = "No active session";
         deleteBtn.disabled = true;
+        escalateBtn.disabled = true;
         return;
       }
 
       titleEl.textContent = active.title || "Untitled Session";
       deleteBtn.disabled = false;
+      escalateBtn.disabled = false;
 
       if (!active.messages.length) {
         const empty = document.createElement("div");
@@ -860,6 +1226,9 @@ class JoshGptSessionViewProvider {
       sendBtn.disabled = state.busy;
       sendBtn.textContent = state.busy ? "Sending..." : "Send";
       promptInput.disabled = state.busy;
+      if (state.busy) {
+        escalateBtn.disabled = true;
+      }
     }
 
     function renderSettings(force) {
@@ -902,6 +1271,13 @@ class JoshGptSessionViewProvider {
       const active = activeSession();
       if (!active) return;
       vscode.postMessage({ type: "deleteSession", sessionId: active.id });
+    });
+
+    escalateBtn.addEventListener("click", () => {
+      if (state.busy) return;
+      const active = activeSession();
+      if (!active) return;
+      vscode.postMessage({ type: "escalateToSupervisor" });
     });
 
     toggleSessionsBtn.addEventListener("click", () => {

--- a/src/supervision-profile-resolver.js
+++ b/src/supervision-profile-resolver.js
@@ -1,0 +1,193 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const DEFAULT_SCOPE_ID = "extension-supervisor-scope";
+const DEFAULT_TARGETS = ["workspace"];
+const DEFAULT_REQUESTED_DECISION = "next_step";
+
+const ALLOWED_REQUESTED_DECISION = new Set([
+  "next_step",
+  "prioritize",
+  "deconflict",
+  "stop_or_continue"
+]);
+
+function asString(value) {
+  return String(value || "").trim();
+}
+
+function asStringList(value, maxItems = 20) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const out = [];
+  for (const item of value) {
+    const text = asString(item);
+    if (!text) {
+      continue;
+    }
+    out.push(text);
+    if (out.length >= maxItems) {
+      break;
+    }
+  }
+  return out;
+}
+
+function normalizeRequestedDecision(value, fallback = DEFAULT_REQUESTED_DECISION) {
+  const normalized = asString(value).toLowerCase();
+  if (ALLOWED_REQUESTED_DECISION.has(normalized)) {
+    return normalized;
+  }
+  return fallback;
+}
+
+function normalizeProfile(raw, { source, filePath }) {
+  const profile = raw && typeof raw === "object" ? raw : {};
+  const workerRoleSlug = asString(
+    profile.worker_role_slug || profile.workerRoleSlug
+  );
+  const supervisorRoleSlug = asString(
+    profile.supervisor_role_slug || profile.supervisorRoleSlug
+  );
+
+  if (!workerRoleSlug || !supervisorRoleSlug) {
+    return {
+      ok: false,
+      source,
+      filePath,
+      error:
+        "Supervision profile requires non-empty worker_role_slug and supervisor_role_slug."
+    };
+  }
+
+  return {
+    ok: true,
+    source,
+    filePath,
+    profile: {
+      workerRoleSlug,
+      supervisorRoleSlug,
+      authorizedScopeId: asString(
+        profile.authorized_scope_id || profile.authorizedScopeId
+      ) || DEFAULT_SCOPE_ID,
+      authorizedTargets: (() => {
+        const targets = asStringList(
+          profile.authorized_targets || profile.authorizedTargets,
+          20
+        );
+        return targets.length ? targets : DEFAULT_TARGETS;
+      })(),
+      requestedDecisionDefault: normalizeRequestedDecision(
+        profile.requested_decision_default || profile.requestedDecisionDefault,
+        DEFAULT_REQUESTED_DECISION
+      )
+    }
+  };
+}
+
+function resolveProfileFromWorkspaceFile(workspaceRoot) {
+  const root = asString(workspaceRoot) || process.cwd();
+  const filePath = path.join(root, ".joshgpt", "supervision.json");
+  if (!fs.existsSync(filePath)) {
+    return {
+      ok: false,
+      source: "workspace_file",
+      filePath,
+      error: "Supervision profile file not found."
+    };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (err) {
+    return {
+      ok: false,
+      source: "workspace_file",
+      filePath,
+      error: `Failed to parse supervision profile JSON: ${err instanceof Error ? err.message : String(err)}`
+    };
+  }
+
+  if (Number(parsed && parsed.version) !== 1) {
+    return {
+      ok: false,
+      source: "workspace_file",
+      filePath,
+      error: "Supervision profile requires version=1."
+    };
+  }
+
+  return normalizeProfile(parsed, {
+    source: "workspace_file",
+    filePath
+  });
+}
+
+function resolveProfileFromSettingsFallback(settingsFallback = {}) {
+  const normalized = normalizeProfile(
+    {
+      worker_role_slug: settingsFallback.workerRoleSlug,
+      supervisor_role_slug: settingsFallback.supervisorRoleSlug,
+      authorized_scope_id: settingsFallback.authorizedScopeId,
+      authorized_targets: settingsFallback.authorizedTargets,
+      requested_decision_default: settingsFallback.requestedDecisionDefault
+    },
+    {
+      source: "settings_fallback",
+      filePath: ""
+    }
+  );
+  if (!normalized.ok) {
+    return {
+      ...normalized,
+      error:
+        "Settings fallback requires joshgpt.supervisor.workerRoleSlug and " +
+        "joshgpt.supervisor.supervisorRoleSlug."
+    };
+  }
+  return normalized;
+}
+
+function resolveSupervisionProfile({ workspaceRoot, settingsFallback = {} } = {}) {
+  const fromWorkspace = resolveProfileFromWorkspaceFile(workspaceRoot);
+  if (fromWorkspace.ok) {
+    return {
+      resolved: true,
+      source: "workspace_file",
+      profile: fromWorkspace.profile,
+      filePath: fromWorkspace.filePath,
+      warning: "",
+      error: ""
+    };
+  }
+
+  const fromSettings = resolveProfileFromSettingsFallback(settingsFallback);
+  if (fromSettings.ok) {
+    return {
+      resolved: true,
+      source: "settings_fallback",
+      profile: fromSettings.profile,
+      filePath: fromWorkspace.filePath,
+      warning:
+        "Workspace supervision profile unavailable; using settings fallback role bindings.",
+      error: ""
+    };
+  }
+
+  return {
+    resolved: false,
+    source: "none",
+    profile: null,
+    filePath: fromWorkspace.filePath,
+    warning: "",
+    error: fromWorkspace.error || fromSettings.error || "No supervision profile available."
+  };
+}
+
+module.exports = {
+  resolveSupervisionProfile
+};

--- a/src/supervisor-readiness.js
+++ b/src/supervisor-readiness.js
@@ -1,0 +1,152 @@
+"use strict";
+
+const { McpHttpClient } = require("./mcp-client");
+
+const REQUIRED_DISPATCHER_TOOLS = [
+  "dispatch_role_task",
+  "submit_supervisor_question",
+  "respond_supervisor_question"
+];
+const REQUIRED_CAPABILITY_TOOLS = ["ask_codex_supervisor"];
+
+function asString(value) {
+  return String(value || "").trim();
+}
+
+function hasMissingTools(toolNames, requiredToolNames) {
+  const available = new Set((toolNames || []).map((name) => String(name || "")));
+  return requiredToolNames.filter((name) => !available.has(name));
+}
+
+function buildCheck(name, ok, detail) {
+  return {
+    name: String(name),
+    ok: Boolean(ok),
+    detail: String(detail || "")
+  };
+}
+
+function summarizeChecks(checks) {
+  const failures = checks.filter((check) => !check.ok);
+  if (!failures.length) {
+    return "Supervisor readiness checks passed.";
+  }
+  return failures.map((check) => `${check.name}: ${check.detail}`).join(" | ");
+}
+
+async function checkMcpTools({
+  label,
+  baseUrl,
+  timeoutMs,
+  requiredToolNames,
+  mcpClientFactory,
+  output
+}) {
+  try {
+    const client = mcpClientFactory({
+      baseUrl,
+      timeoutMs,
+      output
+    });
+    const tools = await client.listTools();
+    const names = tools.map((tool) => (tool && tool.name ? String(tool.name) : ""));
+    const missing = hasMissingTools(names, requiredToolNames);
+    if (missing.length) {
+      return buildCheck(
+        label,
+        false,
+        `Missing required tool(s): ${missing.join(", ")}`
+      );
+    }
+    return buildCheck(label, true, `${names.length} tools listed.`);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return buildCheck(label, false, detail);
+  }
+}
+
+async function checkSupervisorReadiness({
+  dispatcherBaseUrl,
+  capabilityBaseUrl,
+  timeoutMs = 15000,
+  env = process.env,
+  mcpClientFactory = (options) => new McpHttpClient(options),
+  output = null
+} = {}) {
+  const checks = [];
+  const dispatcherUrl = asString(dispatcherBaseUrl);
+  const capabilityUrl = asString(capabilityBaseUrl);
+  const dispatcherToken = asString(env.JOSHGPT_DISPATCHER_SHARED_TOKEN);
+  const supervisorToken = asString(env.JOSHGPT_SUPERVISOR_SHARED_TOKEN);
+
+  checks.push(
+    buildCheck(
+      "dispatcher_url",
+      Boolean(dispatcherUrl),
+      dispatcherUrl ? dispatcherUrl : "joshgpt.supervisor.dispatcherBaseUrl is empty."
+    )
+  );
+  checks.push(
+    buildCheck(
+      "capability_url",
+      Boolean(capabilityUrl),
+      capabilityUrl ? capabilityUrl : "joshgpt.supervisor.capabilityBaseUrl is empty."
+    )
+  );
+  checks.push(
+    buildCheck(
+      "dispatcher_token",
+      Boolean(dispatcherToken),
+      dispatcherToken
+        ? "JOSHGPT_DISPATCHER_SHARED_TOKEN is present."
+        : "JOSHGPT_DISPATCHER_SHARED_TOKEN is missing."
+    )
+  );
+  checks.push(
+    buildCheck(
+      "supervisor_token",
+      Boolean(supervisorToken),
+      supervisorToken
+        ? "JOSHGPT_SUPERVISOR_SHARED_TOKEN is present."
+        : "JOSHGPT_SUPERVISOR_SHARED_TOKEN is missing."
+    )
+  );
+
+  const urlsOk = checks[0].ok && checks[1].ok;
+  if (urlsOk) {
+    checks.push(
+      await checkMcpTools({
+        label: "dispatcher_mcp",
+        baseUrl: dispatcherUrl,
+        timeoutMs,
+        requiredToolNames: REQUIRED_DISPATCHER_TOOLS,
+        mcpClientFactory,
+        output
+      })
+    );
+    checks.push(
+      await checkMcpTools({
+        label: "capability_mcp",
+        baseUrl: capabilityUrl,
+        timeoutMs,
+        requiredToolNames: REQUIRED_CAPABILITY_TOOLS,
+        mcpClientFactory,
+        output
+      })
+    );
+  }
+
+  const ready = checks.every((check) => check.ok);
+  return {
+    ready,
+    status: ready ? "ready" : "blocked",
+    checks,
+    summary: summarizeChecks(checks)
+  };
+}
+
+module.exports = {
+  REQUIRED_DISPATCHER_TOOLS,
+  REQUIRED_CAPABILITY_TOOLS,
+  checkSupervisorReadiness
+};

--- a/src/supervisor-wrapper-tool.js
+++ b/src/supervisor-wrapper-tool.js
@@ -34,6 +34,11 @@ const ALLOWED_REQUESTED_DECISION = new Set([
 ]);
 const TERMINAL_DECISIONS = new Set(["pause_for_human", "stop"]);
 
+const DEFAULT_SCOPE_ID = "extension-supervisor-scope";
+const DEFAULT_TARGETS = ["workspace"];
+const DEFAULT_REQUESTED_DECISION = "next_step";
+const DEFAULT_ESCALATION_REASON = "needs_supervisor_decision";
+
 function asString(value) {
   return String(value || "").trim();
 }
@@ -74,6 +79,29 @@ function isoUtcPlusHours(now, hours) {
 
 function sha256Hex(value) {
   return crypto.createHash("sha256").update(String(value || ""), "utf8").digest("hex");
+}
+
+function abbreviate(text, maxChars = 220) {
+  const normalized = asString(text).replace(/\s+/g, " ");
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxChars)}...`;
+}
+
+function chooseList(primary, fallback, maxItems = 20) {
+  const first = asStringList(primary, maxItems);
+  if (first.length) {
+    return first;
+  }
+  return asStringList(fallback, maxItems);
+}
+
+function normalizeQuestionForHash(input) {
+  return asString(input)
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .slice(0, 2000);
 }
 
 function tryParseJsonObject(text) {
@@ -118,6 +146,28 @@ function unwrapToolResult(raw) {
   return raw;
 }
 
+function buildPauseForHumanDecision(reason, nextActions = []) {
+  const fallbackNextActions = nextActions.length
+    ? nextActions
+    : [
+        "Review the escalation context and confirm supervisor endpoints are reachable.",
+        "Verify dispatcher/supervisor shared tokens are present in extension environment.",
+        "Retry escalation after resolving runtime/auth issues."
+      ];
+  return {
+    decision: "pause_for_human",
+    rationale: `Supervisor wrapper fail-safe: ${asString(reason) || "manual review required."}`,
+    next_actions: fallbackNextActions,
+    confidence: 0.1,
+    safety_checks: [
+      "Token handling remained extension-local",
+      "Escalation payload captured",
+      "Human review required before continuation"
+    ],
+    audit_tags: ["fail-safe", "supervisor-wrapper"]
+  };
+}
+
 function asSupervisorDecisionPayload(raw, reasonIfInvalid = "") {
   const decision = unwrapToolResult(raw);
   if (
@@ -137,25 +187,6 @@ function asSupervisorDecisionPayload(raw, reasonIfInvalid = "") {
   return buildPauseForHumanDecision(
     reasonIfInvalid || "Supervisor returned malformed decision payload."
   );
-}
-
-function buildPauseForHumanDecision(reason) {
-  return {
-    decision: "pause_for_human",
-    rationale: `Supervisor wrapper fail-safe: ${asString(reason) || "manual review required."}`,
-    next_actions: [
-      "Review the escalation context and confirm supervisor endpoints are reachable.",
-      "Verify dispatcher/supervisor shared tokens are present in extension environment.",
-      "Retry escalation after resolving runtime/auth issues."
-    ],
-    confidence: 0.1,
-    safety_checks: [
-      "Token handling remained extension-local",
-      "Escalation payload captured",
-      "Human review required before continuation"
-    ],
-    audit_tags: ["fail-safe", "supervisor-wrapper"]
-  };
 }
 
 function buildWrapperResult({
@@ -181,6 +212,21 @@ function buildWrapperResult({
     dispatcher: dispatcherSummary,
     error: asString(error)
   };
+}
+
+function buildGuardrailBlockedWrapperResult(reason) {
+  return buildWrapperResult({
+    ok: false,
+    error: asString(reason) || "Supervisor escalation blocked by policy guardrail.",
+    decisionPayload: buildPauseForHumanDecision(
+      asString(reason) || "Supervisor escalation blocked by policy guardrail.",
+      [
+        "Review recent escalation attempts in trace logs.",
+        "Adjust supervisor guardrail settings if tighter policy is unintended.",
+        "Retry escalation after cooldown or with materially new context."
+      ]
+    )
+  });
 }
 
 function buildGuardedSupervisorMessage(wrapperResult) {
@@ -215,19 +261,8 @@ function getSupervisorWrapperOpenAiTool() {
         type: "object",
         additionalProperties: false,
         properties: {
-          worker_role_slug: { type: "string" },
-          supervisor_role_slug: { type: "string" },
-          objective: { type: "string" },
-          escalation_reason: { type: "string" },
           question: { type: "string" },
-          role_context_ref: { type: "string" },
-          constraints: { type: "array", items: { type: "string" }, maxItems: 20 },
-          input_refs: { type: "array", items: { type: "string" }, maxItems: 20 },
-          mission_id: { type: "string" },
-          current_phase: {
-            type: "string",
-            enum: ["discovery", "classification", "validation", "reporting"]
-          },
+          escalation_reason: { type: "string" },
           blocked_reason: {
             type: "string",
             enum: [
@@ -238,81 +273,210 @@ function getSupervisorWrapperOpenAiTool() {
               "repeated_failure"
             ]
           },
+          current_phase: {
+            type: "string",
+            enum: ["discovery", "classification", "validation", "reporting"]
+          },
           attempt_history: { type: "array", items: { type: "string" }, maxItems: 20 },
           evidence_summary: { type: "string" },
-          authorized_scope_id: { type: "string" },
-          authorized_targets: { type: "array", items: { type: "string" }, maxItems: 20 },
-          authorized_expires_utc: { type: "string" },
           requested_decision: {
             type: "string",
             enum: ["next_step", "prioritize", "deconflict", "stop_or_continue"]
           }
         },
-        required: [
-          "worker_role_slug",
-          "supervisor_role_slug",
-          "objective",
-          "escalation_reason",
-          "question"
-        ]
+        required: ["question"]
       }
     }
   };
 }
 
-function buildDispatcherTaskPayload(input) {
+function resolveGuardrailPolicy(policy = {}) {
+  const maxPerTurn = Math.max(1, Number(policy.maxPerTurn) || 1);
+  const maxPerSession = Math.max(1, Number(policy.maxPerSession) || 3);
+  const cooldownMs = Math.max(0, Number(policy.cooldownMs) || 15000);
   return {
-    task_id: asString(input.mission_id) || crypto.randomUUID(),
-    worker_role_slug: asString(input.worker_role_slug),
-    supervisor_role_slug: asString(input.supervisor_role_slug),
-    objective: asString(input.objective),
-    constraints: asStringList(input.constraints, 20),
-    input_refs: asStringList(input.input_refs, 20)
+    maxPerTurn,
+    maxPerSession,
+    cooldownMs
   };
 }
 
-function buildSupervisorRequestPayload(input, missionId, now) {
-  const constraints = asStringList(input.constraints, 20);
-  const authorizedTargets = asStringList(input.authorized_targets, 20);
-  const effectiveTargets = authorizedTargets.length > 0 ? authorizedTargets : ["workspace"];
-  const evidenceSummary = asString(input.evidence_summary);
+function evaluateSupervisorEscalationGuardrails({
+  input,
+  state = {},
+  policy = {},
+  nowMs = Date.now()
+} = {}) {
+  const rules = resolveGuardrailPolicy(policy);
+  const currentState = {
+    turnEscalationCount: Math.max(0, Number(state.turnEscalationCount) || 0),
+    sessionEscalationCount: Math.max(0, Number(state.sessionEscalationCount) || 0),
+    lastEscalationAtMs: Math.max(0, Number(state.lastEscalationAtMs) || 0),
+    lastEscalationQuestionHash: asString(state.lastEscalationQuestionHash)
+  };
+  const question = asString(input && input.question);
+  if (!question) {
+    return {
+      allowed: false,
+      reason: "Supervisor escalation requires a non-empty question.",
+      state: currentState
+    };
+  }
+  if (currentState.turnEscalationCount >= rules.maxPerTurn) {
+    return {
+      allowed: false,
+      reason: `Supervisor escalation blocked: per-turn limit reached (${rules.maxPerTurn}).`,
+      state: currentState
+    };
+  }
+  if (currentState.sessionEscalationCount >= rules.maxPerSession) {
+    return {
+      allowed: false,
+      reason: `Supervisor escalation blocked: per-session limit reached (${rules.maxPerSession}).`,
+      state: currentState
+    };
+  }
+
+  if (rules.cooldownMs > 0 && currentState.lastEscalationAtMs > 0) {
+    const elapsedMs = nowMs - currentState.lastEscalationAtMs;
+    if (elapsedMs < rules.cooldownMs) {
+      const hash = sha256Hex(normalizeQuestionForHash(question));
+      if (hash === currentState.lastEscalationQuestionHash) {
+        return {
+          allowed: false,
+          reason:
+            "Supervisor escalation blocked: duplicate escalation during cooldown window.",
+          state: currentState
+        };
+      }
+      return {
+        allowed: false,
+        reason: `Supervisor escalation blocked: cooldown active (${rules.cooldownMs}ms).`,
+        state: currentState
+      };
+    }
+  }
+
+  const nextState = {
+    turnEscalationCount: currentState.turnEscalationCount + 1,
+    sessionEscalationCount: currentState.sessionEscalationCount + 1,
+    lastEscalationAtMs: nowMs,
+    lastEscalationQuestionHash: sha256Hex(normalizeQuestionForHash(question))
+  };
   return {
-    mission_id: asString(missionId),
-    goal: asString(input.objective),
-    current_phase: chooseEnum(input.current_phase, ALLOWED_CURRENT_PHASE, "validation"),
-    blocked_reason: chooseEnum(
-      input.blocked_reason,
+    allowed: true,
+    reason: "",
+    state: nextState
+  };
+}
+
+function buildEffectiveEscalationContext(
+  input,
+  { supervisionProfile, sessionContext = {}, now = new Date() } = {}
+) {
+  const profile = supervisionProfile || {};
+  const objective =
+    asString(input.objective) ||
+    asString(sessionContext.objective) ||
+    abbreviate(asString(input.question), 220) ||
+    "Resolve current blocker with supervisor guidance.";
+  const roleContextRef =
+    asString(input.role_context_ref) ||
+    asString(sessionContext.roleContextRef) ||
+    "workspace://AGENTS.md";
+  const constraints = chooseList(input.constraints, sessionContext.constraints, 20);
+  const inputRefs = chooseList(input.input_refs, sessionContext.inputRefs, 20);
+  const attemptHistory = chooseList(
+    input.attempt_history,
+    sessionContext.attemptHistory,
+    20
+  );
+  const authorizedTargets = chooseList(
+    profile.authorizedTargets,
+    DEFAULT_TARGETS,
+    20
+  );
+
+  return {
+    missionId: asString(input.mission_id || sessionContext.missionId) || crypto.randomUUID(),
+    workerRoleSlug: asString(profile.workerRoleSlug),
+    supervisorRoleSlug: asString(profile.supervisorRoleSlug),
+    objective,
+    escalationReason:
+      asString(input.escalation_reason) ||
+      asString(sessionContext.escalationReason) ||
+      DEFAULT_ESCALATION_REASON,
+    question: asString(input.question),
+    roleContextRef,
+    constraints,
+    inputRefs,
+    currentPhase: chooseEnum(
+      input.current_phase || sessionContext.currentPhase,
+      ALLOWED_CURRENT_PHASE,
+      "validation"
+    ),
+    blockedReason: chooseEnum(
+      input.blocked_reason || sessionContext.blockedReason,
       ALLOWED_BLOCKED_REASON,
       "insufficient_context"
     ),
-    attempt_history: asStringList(input.attempt_history, 20),
-    evidence_summary: evidenceSummary,
-    constraints,
-    authorized_scope: {
-      scope_id: asString(input.authorized_scope_id) || "extension-supervisor-scope",
-      targets: effectiveTargets,
-      expires_utc:
-        asString(input.authorized_expires_utc) || isoUtcPlusHours(now, 1)
-    },
-    requested_decision: chooseEnum(
-      input.requested_decision,
+    attemptHistory,
+    evidenceSummary:
+      asString(input.evidence_summary) || asString(sessionContext.evidenceSummary),
+    authorizedScopeId: asString(profile.authorizedScopeId) || DEFAULT_SCOPE_ID,
+    authorizedTargets,
+    authorizedExpiresUtc:
+      asString(input.authorized_expires_utc || sessionContext.authorizedExpiresUtc) ||
+      isoUtcPlusHours(now, 1),
+    requestedDecision: chooseEnum(
+      input.requested_decision ||
+        sessionContext.requestedDecision ||
+        profile.requestedDecisionDefault,
       ALLOWED_REQUESTED_DECISION,
-      "next_step"
+      DEFAULT_REQUESTED_DECISION
     )
   };
 }
 
-function buildSupervisorQuestionPayload(input, taskId) {
-  const roleContextRef = asString(input.role_context_ref) || "workspace://AGENTS.md";
+function buildDispatcherTaskPayload(context) {
+  return {
+    task_id: context.missionId,
+    worker_role_slug: context.workerRoleSlug,
+    supervisor_role_slug: context.supervisorRoleSlug,
+    objective: context.objective,
+    constraints: context.constraints,
+    input_refs: context.inputRefs
+  };
+}
+
+function buildSupervisorRequestPayload(context) {
+  return {
+    mission_id: context.missionId,
+    goal: context.objective,
+    current_phase: context.currentPhase,
+    blocked_reason: context.blockedReason,
+    attempt_history: context.attemptHistory,
+    evidence_summary: context.evidenceSummary,
+    constraints: context.constraints,
+    authorized_scope: {
+      scope_id: context.authorizedScopeId,
+      targets: context.authorizedTargets,
+      expires_utc: context.authorizedExpiresUtc
+    },
+    requested_decision: context.requestedDecision
+  };
+}
+
+function buildSupervisorQuestionPayload(context, taskId) {
   return {
     task_id: asString(taskId),
-    from_role_slug: asString(input.worker_role_slug),
-    to_supervisor_role_slug: asString(input.supervisor_role_slug),
-    escalation_reason: asString(input.escalation_reason),
-    question: asString(input.question),
-    role_context_ref: roleContextRef,
+    from_role_slug: context.workerRoleSlug,
+    to_supervisor_role_slug: context.supervisorRoleSlug,
+    escalation_reason: context.escalationReason,
+    question: context.question,
+    role_context_ref: context.roleContextRef,
     role_context_sha256: sha256Hex(
-      `${roleContextRef}\n${asString(input.objective)}\n${asString(input.question)}`
+      `${context.roleContextRef}\n${context.objective}\n${context.question}`
     )
   };
 }
@@ -325,6 +489,9 @@ async function runSupervisorWrapperToolCall(
     timeoutMs = 15000,
     output = null,
     env = process.env,
+    supervisionProfile = null,
+    supervisionProfileSource = "",
+    sessionContext = {},
     mcpClientFactory = (options) => new McpHttpClient(options),
     nowFactory = () => new Date()
   } = {}
@@ -349,6 +516,31 @@ async function runSupervisorWrapperToolCall(
   }
 
   const now = nowFactory();
+  const context = buildEffectiveEscalationContext(input, {
+    supervisionProfile,
+    sessionContext,
+    now
+  });
+  if (!context.workerRoleSlug || !context.supervisorRoleSlug) {
+    return buildWrapperResult({
+      ok: false,
+      error:
+        "Supervisor wrapper requires resolved worker/supervisor role bindings in supervision profile."
+    });
+  }
+  if (!context.objective) {
+    return buildWrapperResult({
+      ok: false,
+      error: "Supervisor wrapper could not derive an objective from session context."
+    });
+  }
+  if (!context.question) {
+    return buildWrapperResult({
+      ok: false,
+      error: "Supervisor wrapper requires a non-empty question."
+    });
+  }
+
   const dispatcherClient = mcpClientFactory({
     baseUrl: dispatcherUrl,
     timeoutMs,
@@ -360,29 +552,11 @@ async function runSupervisorWrapperToolCall(
     output
   });
 
-  const taskPayload = buildDispatcherTaskPayload(input);
-  if (
-    !taskPayload.worker_role_slug ||
-    !taskPayload.supervisor_role_slug ||
-    !taskPayload.objective
-  ) {
-    return buildWrapperResult({
-      ok: false,
-      error:
-        "Supervisor wrapper requires worker_role_slug, supervisor_role_slug, and objective."
-    });
-  }
-  if (!asString(input.escalation_reason) || !asString(input.question)) {
-    return buildWrapperResult({
-      ok: false,
-      error: "Supervisor wrapper requires escalation_reason and question."
-    });
-  }
-
   let taskId = "";
   let messageId = "";
 
   try {
+    const taskPayload = buildDispatcherTaskPayload(context);
     const dispatchResponseRaw = await dispatcherClient.callTool("dispatch_role_task", {
       payload: taskPayload,
       shared_token: dispatcherToken
@@ -393,7 +567,7 @@ async function runSupervisorWrapperToolCall(
       throw new Error("Dispatcher did not return task_id.");
     }
 
-    const questionPayload = buildSupervisorQuestionPayload(input, taskId);
+    const questionPayload = buildSupervisorQuestionPayload(context, taskId);
     const questionResponseRaw = await dispatcherClient.callTool(
       "submit_supervisor_question",
       {
@@ -407,11 +581,10 @@ async function runSupervisorWrapperToolCall(
       throw new Error("Dispatcher did not return message_id.");
     }
 
-    const supervisorRequestPayload = buildSupervisorRequestPayload(input, taskId, now);
     const supervisorDecisionRaw = await supervisorClient.callTool(
       "ask_codex_supervisor",
       {
-        payload: supervisorRequestPayload,
+        payload: buildSupervisorRequestPayload(context),
         shared_token: supervisorToken
       }
     );
@@ -422,7 +595,7 @@ async function runSupervisorWrapperToolCall(
 
     const responseAckRaw = await dispatcherClient.callTool("respond_supervisor_question", {
       message_id: messageId,
-      supervisor_role_slug: taskPayload.supervisor_role_slug,
+      supervisor_role_slug: context.supervisorRoleSlug,
       decision_payload: supervisorDecision,
       shared_token: dispatcherToken
     });
@@ -437,7 +610,8 @@ async function runSupervisorWrapperToolCall(
         dispatch_status: asString(dispatchResponse.status || "queued"),
         question_status: asString(questionResponse.status || "pending"),
         response_status: asString(responseAck.status || "answered"),
-        submitted_at: isoUtcNow(now)
+        submitted_at: isoUtcNow(now),
+        role_source: asString(supervisionProfileSource) || "unknown"
       }
     });
   } catch (err) {
@@ -455,6 +629,8 @@ module.exports = {
   SUPERVISOR_WRAPPER_TOOL_NAME,
   INTERNAL_SUPERVISOR_TOOL_NAMES,
   getSupervisorWrapperOpenAiTool,
+  evaluateSupervisorEscalationGuardrails,
+  buildGuardrailBlockedWrapperResult,
   runSupervisorWrapperToolCall,
   buildGuardedSupervisorMessage
 };


### PR DESCRIPTION
## Summary
- switch supervisor flow to model-initiated escalation by default with minimal tool args
- add supervision profile resolution (`.joshgpt/supervision.json` with settings fallback)
- add supervisor readiness checks (auto preflight + status command)
- add escalation guardrails (per-turn/per-session/cooldown)
- add manual fallback escalation command + session UI button
- add tests for supervision profile and readiness modules

## Validation
- npm run test:instructions
- npm run test:supervision-profile
- npm run test:supervisor-readiness
- npm run test:supervisor-wrapper
- npm run test:local-shell

## Notes
- `test:client`, `test:native`, and `test:mcp` require reachable local endpoints and were not green in this environment (`fetch failed`).
