### PR TITLE
Bump extension version to 0.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "joshgpt",
   "displayName": "JoshGPT",
   "description": "Minimal JoshGPT VS Code extension template with LM Studio support, local shell tooling, and optional MCP integrations.",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "publisher": "josh-phillips-llc",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- bump extension version from `0.0.10` to `0.0.11`
- no functional changes

## Reason
- make the deployed extension build clearly distinguishable from prior `0.0.10` builds during UI testing.
